### PR TITLE
Fetch program data on provider mount

### DIFF
--- a/src/contexts/ProgramContext.jsx
+++ b/src/contexts/ProgramContext.jsx
@@ -1,9 +1,14 @@
-import { createContext, useState, useMemo, useContext } from 'react';
+import { createContext, useState, useMemo, useContext, useEffect } from 'react';
+import { fetchPrograms } from '../utils/api';
 
 export const ProgramContext = createContext(null);
 
 export function ProgramProvider({ children }) {
   const [programs, setPrograms] = useState([]);
+
+  useEffect(() => {
+    fetchPrograms().then(setPrograms);
+  }, []);
 
   const value = useMemo(() => ({ programs, setPrograms }), [programs]);
 


### PR DESCRIPTION
## Summary
- load programs once in `ProgramProvider` using `fetchPrograms`

## Testing
- `npm run lint` *(fails: react-refresh/only-export-components and unused vars errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a55bfb840832d8370f5ba44d5c2cc